### PR TITLE
Fix for empty Q objects

### DIFF
--- a/liquer.py
+++ b/liquer.py
@@ -121,7 +121,7 @@ class CompoundQuery(Query):
         :param type: lambda
 
         '''
-        self.queries = args
+        self.queries = [arg for arg in args if getattr(arg, 'queries', True)]
         self.op = kwargs.pop('op', lambda x, y: x and y)
         super(CompoundQuery, self).__init__()
 

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,7 @@ class TestLiquer(unittest.TestCase):
         self.assertTrue((Q(foo__bar='Hello World!') | Q(foo__baz=2))(a))
         self.assertFalse((Q(foo__bar='Hello World!') & Q(foo__baz=2))(a))
         self.assertTrue((Q(foo__bar='Hello World!') & Q(foo__baz=1))(a))
+        self.assertTrue((Q() | Q(foo__bar__icontains='hello'))(a))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In Django, it is common to end up with empty Q objects when you're building the final Q object. For example:

``` python
q = Q()
for arg in args:
    if some_condition(arg):
        q |= Q(arg_name=arg)
```

The Django ORM discards those when applying the filter.

Without this fix, I would get the following exception:

```
  File "/home/imiric/liquer/liquer.py", line 106, in __call__
    return self._test(obj)
  File "/home/imiric/liquer/liquer.py", line 130, in _test
    return reduce(self.op, [query(obj) for query in self.queries])
TypeError: reduce() of empty sequence with no initial value
```

Not sure if this is the most elegant way of solving this, so let me know.
